### PR TITLE
Removed unnecessary(?) YAML hint

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -951,8 +951,6 @@ To relate the ``Category`` and ``Product`` entities, start by creating a
                 products:
                     targetEntity: Product
                     mappedBy: category
-            # don't forget to init the collection in the __construct() method
-            # of the entity
 
     .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | [yes] |
| New docs? | [no] |
| Applies to | [2.3] |
| Fixed tickets | [] |

I guess it's not necessary to do anything in __construct manually - the ArrayCollection is automatically initialized when you do php app/console doctrine:generate:entities AppBundle

Please double-check!
